### PR TITLE
Fixed and formatted build.gradle for 1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,9 @@ buildscript {
         maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
     }
     dependencies {
-        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
+        // MixinGradle:
+        classpath 'org.spongepowered:mixingradle:0.7.+'
     }
 }
 
@@ -21,16 +23,11 @@ minecraft {
 
 dependencies {
     minecraft "net.minecraftforge:forge:${project.minecraft_version}-${project.forge_version}"
+    
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }
 
 mixin {
     add sourceSets.main, "xlpackets.refmap.json"
-}
-
-processResources {
-    inputs.property 'version', project.version
-
-    filesMatching("META-INF/mods.toml") {
-        expand "version": project.version
-    }
+    config 'xlpackets.mixins.json'
 }


### PR DESCRIPTION
I was able to use the changes from this branch in conjunction with some updates to the build configuration to get packet size correctly mixed in!